### PR TITLE
Verify `MasterSummary` against Gibbername

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,4 +60,5 @@ melprot = "0.13.4"
 melstructs = "0.3.2"
 gibbername = { git = "https://github.com/mel-project/gibbername", branch = "master" }
 melbootstrap = "0.8.3"
+tmelcrypt = "0.2.7"
 # sosistab= "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,5 @@ dashmap = "5.4.0"
 melprot = "0.13.4"
 melstructs = "0.3.2"
 gibbername = { git = "https://github.com/mel-project/gibbername", branch = "master" }
+melbootstrap = "0.8.3"
 # sosistab= "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,4 +56,7 @@ arrayref = "0.3.6"
 rsa = {version = "0.3", features=["serde"]}
 native-tls = {version="0.2", features=["vendored"]}
 dashmap = "5.4.0"
+melprot = "0.13.4"
+melstructs = "0.3.2"
+gibbername = { git = "https://github.com/mel-project/gibbername", branch = "master" }
 # sosistab= "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ x25519-dalek={ version = "1.2.0", features = ["serde"], default-features=false }
 nanorpc = "0.1.7"
 async-trait = "0.1.57"
 thiserror = "1.0.37"
-smol_str = "0.1.23"
+smol_str = { version = "0.1.23", features = ["serde"] }
 stdcode = "0.1.10"
 base64 = "0.13.0"
 serde_with = {version="2.0.1", features=["base64", "hex"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ license="GPL-3.0-only"
 
 acidjson= "0.1.2"
 anyhow = "1.0.65"
-async-net= "1.7.0"
+async-net = "1.7.0"
 bincode = "1.3.3"
-bytes={ version = "1.2.1", features = ["serde"] }
+bytes = { version = "1.2.1", features = ["serde"] }
 ed25519-dalek={ version = "1.0.1", features = ["serde"] }
 event-listener= "2.5.3"
 fastrand = "1.8.0"

--- a/src/binder/client.rs
+++ b/src/binder/client.rs
@@ -64,11 +64,11 @@ impl CachedBinderClient {
 
         // load from the network
         let summary = self.inner.get_summary().await?;
-        log::info!("summary from binder: {:?}", summary);
+
         if !self.verify_summary(&summary).await? {
             anyhow::bail!(
-                "summary from binder: {:?} does not match gibbername summary history",
-                &summary
+                "summary hash from binder: {:?} does not match gibbername summary history",
+                summary.clean_hash()
             );
         }
 
@@ -83,7 +83,10 @@ impl CachedBinderClient {
     /// Verifies the given [`MasterSummary`] against what is stored in a gibbername chain on Mel.
     async fn verify_summary(&self, summary: &MasterSummary) -> anyhow::Result<bool> {
         let my_summary_hash = summary.clean_hash();
-        log::info!("about to verify summary hash: {:?}", my_summary_hash);
+        log::info!(
+            "about to verify summary hash from binder: {:?}",
+            my_summary_hash
+        );
 
         // TODO: connect to a melnode in a "reverse-proxy" manner.
         let client = melprot::Client::autoconnect(melstructs::NetID::Mainnet).await?;

--- a/src/binder/client.rs
+++ b/src/binder/client.rs
@@ -24,7 +24,7 @@ use super::protocol::{
 };
 
 /// The gibbername bound to a hash of the [`MasterSummary`]. Used to verify the summary response the binder server gives the client.
-const MASTER_SUMMARY_GIBBERNAME: &str = "zelbev-peg";
+const MASTER_SUMMARY_GIBBERNAME: &str = "retmev-peg";
 
 struct CustomRpcTransport {
     binder_client: Arc<DynBinderClient>,

--- a/src/binder/client.rs
+++ b/src/binder/client.rs
@@ -80,6 +80,7 @@ impl CachedBinderClient {
         Ok(summary)
     }
 
+    /// Verifies the given [`MasterSummary`] against what is stored in a gibbername chain on Mel.
     async fn verify_summary(&self, summary: &MasterSummary) -> anyhow::Result<bool> {
         let my_summary_hash = blake3::hash(&summary.stdcode());
         log::info!("about to verify summary hash: {:?}", my_summary_hash);
@@ -90,6 +91,12 @@ impl CachedBinderClient {
 
         log::info!("history from gibbername: {:?}", history);
 
+        // NOTE: There may be an interval where newly updated exit lists in the binder database are't consistent with
+        // what is stored on the corresponding gibbername chain.
+        //
+        // We check from newest to oldest until we find a match, or we run out of bindings.
+        // Old domain names being used by other people is not a threat because
+        // we also hash the sosistab2 public key of the servers, which other people can't get.
         Ok(history
             .iter()
             .rev()

--- a/src/binder/client.rs
+++ b/src/binder/client.rs
@@ -16,16 +16,14 @@ use reqwest::{
     header::{HeaderMap, HeaderName},
     StatusCode,
 };
-use smol_str::SmolStr;
 
 use super::protocol::{
-    box_decrypt, box_encrypt, AuthError, AuthRequest, AuthRequestV2, AuthResponse, AuthResponseV2,
-    BinderClient, BlindToken, BridgeDescriptor, Credentials, ExitDescriptor, Level, MasterSummary,
-    UserInfo, UserInfoV2,
+    box_decrypt, box_encrypt, AuthError, AuthRequestV2, AuthResponseV2, BinderClient, BlindToken,
+    BridgeDescriptor, Credentials, ExitDescriptor, Level, MasterSummary, UserInfoV2,
 };
 
 /// The gibbername bound to a hash of the [`MasterSummary`]. Used to verify the summary response the binder server gives the client.
-const MASTER_SUMMARY_GIBBERNAME: &str = "retmev-peg";
+const MASTER_SUMMARY_GIBBERNAME: &str = "jermeb-beg";
 
 struct CustomRpcTransport {
     binder_client: Arc<DynBinderClient>,

--- a/src/binder/client.rs
+++ b/src/binder/client.rs
@@ -20,11 +20,11 @@ use smol_str::SmolStr;
 
 use super::protocol::{
     box_decrypt, box_encrypt, AuthError, AuthRequest, AuthResponse, BinderClient, BlindToken,
-    BridgeDescriptor, ExitDescriptor, Level, MasterSummary, RpcError, UserInfo,
+    BridgeDescriptor, ExitDescriptor, Level, MasterSummary, UserInfo,
 };
 
 /// The gibbername bound to a hash of the [`MasterSummary`]. Used to verify the summary response the binder server gives the client.
-const MASTER_SUMMARY_GIBBERNAME: &str = "zemvej-peg";
+const MASTER_SUMMARY_GIBBERNAME: &str = "zelbev-peg";
 
 struct CustomRpcTransport {
     binder_client: Arc<DynBinderClient>,
@@ -36,7 +36,7 @@ impl RpcTransport for CustomRpcTransport {
 
     async fn call_raw(&self, req: JrpcRequest) -> Result<JrpcResponse, Self::Error> {
         let resp = self.binder_client.reverse_proxy_melnode(req).await??;
-        log::info!("resp from CustomRpcTransport::call_raw = {:?}", resp);
+        // log::info!("resp from CustomRpcTransport::call_raw = {:?}", resp);
         Ok(resp)
     }
 }
@@ -105,10 +105,8 @@ impl CachedBinderClient {
     /// we also hash the sosistab2 public key of the servers, which other people can't get.
     async fn verify_summary(&self, summary: &MasterSummary) -> anyhow::Result<bool> {
         let my_summary_hash = summary.clean_hash();
-        log::info!(
-            "about to verify summary hash from binder: {:?}",
-            my_summary_hash
-        );
+        log::info!("about to verify summary hash from binder: {my_summary_hash}");
+        println!("hellllllll0");
 
         // Connect to a melnode that is reverse-proxied through the binder.
         let client = melprot::Client::new(
@@ -123,7 +121,7 @@ impl CachedBinderClient {
         client.trust(trusted_height);
 
         log::info!("^__^ !! created reverse-proxied mel client !! ^__^");
-
+        log::info!("gibbername = {MASTER_SUMMARY_GIBBERNAME}");
         // let client = melprot::Client::autoconnect(melstructs::NetID::Mainnet).await?;
         let history = gibbername::lookup_whole_history(&client, MASTER_SUMMARY_GIBBERNAME).await?;
 

--- a/src/binder/client.rs
+++ b/src/binder/client.rs
@@ -23,7 +23,7 @@ use super::protocol::{
 };
 
 /// The gibbername bound to a hash of the [`MasterSummary`]. Used to verify the summary response the binder server gives the client.
-static MASTER_SUMMARY_GIBBERNAME: &str = "qeppej-peg";
+static MASTER_SUMMARY_GIBBERNAME: &str = "zemvej-peg";
 
 /// A caching, intelligent binder client, generic over the precise mechanism used for caching.
 #[allow(clippy::type_complexity)]

--- a/src/binder/client.rs
+++ b/src/binder/client.rs
@@ -1,5 +1,6 @@
 use std::{
     convert::TryInto,
+    sync::Arc,
     time::{Duration, SystemTime},
 };
 
@@ -8,7 +9,8 @@ use async_compat::CompatExt;
 use async_trait::async_trait;
 use bytes::Bytes;
 
-use nanorpc::{DynRpcTransport, RpcTransport};
+use melprot::NodeRpcClient;
+use nanorpc::{DynRpcTransport, JrpcRequest, JrpcResponse, RpcTransport};
 use rand::{seq::SliceRandom, Rng};
 use reqwest::{
     header::{HeaderMap, HeaderName},
@@ -17,9 +19,28 @@ use reqwest::{
 use smol_str::SmolStr;
 
 use super::protocol::{
-    box_decrypt, box_encrypt, AuthError, AuthRequest, AuthResponse, BinderClient, BlindToken,
-    BridgeDescriptor, ExitDescriptor, Level, MasterSummary, UserInfo,
+    box_decrypt, box_encrypt, AuthError, AuthRequest, AuthRequestV2, AuthResponse, AuthResponseV2,
+    BinderClient, BlindToken, BridgeDescriptor, Credentials, ExitDescriptor, Level, MasterSummary,
+    UserInfo, UserInfoV2,
 };
+
+/// The gibbername bound to a hash of the [`MasterSummary`]. Used to verify the summary response the binder server gives the client.
+const MASTER_SUMMARY_GIBBERNAME: &str = "retmev-peg";
+
+struct CustomRpcTransport {
+    binder_client: Arc<DynBinderClient>,
+}
+
+#[async_trait]
+impl RpcTransport for CustomRpcTransport {
+    type Error = anyhow::Error;
+
+    async fn call_raw(&self, req: JrpcRequest) -> Result<JrpcResponse, Self::Error> {
+        let resp = self.binder_client.reverse_proxy_melnode(req).await??;
+        // log::info!("resp from CustomRpcTransport::call_raw = {:?}", resp);
+        Ok(resp)
+    }
+}
 
 /// A caching, intelligent binder client, generic over the precise mechanism used for caching.
 #[allow(clippy::type_complexity)]
@@ -95,7 +116,7 @@ impl CachedBinderClient {
         // Connect to a melnode that is reverse-proxied through the binder.
         let client = melprot::Client::new(
             melstructs::NetID::Mainnet,
-            NodeRpcClient(CustomRpcTransport {
+            NodeRpcClient::from(CustomRpcTransport {
                 binder_client: self.inner.clone(),
             }),
         );

--- a/src/binder/client.rs
+++ b/src/binder/client.rs
@@ -64,7 +64,7 @@ impl CachedBinderClient {
 
         // load from the network
         let summary = self.inner.get_summary().await?;
-        println!("summary from BINDER: {:?}", summary);
+        log::info!("summary from binder: {:?}", summary);
         if !self.verify_summary(&summary).await? {
             anyhow::bail!(
                 "summary from binder: {:?} does not match gibbername summary history",
@@ -82,7 +82,7 @@ impl CachedBinderClient {
 
     /// Verifies the given [`MasterSummary`] against what is stored in a gibbername chain on Mel.
     async fn verify_summary(&self, summary: &MasterSummary) -> anyhow::Result<bool> {
-        let my_summary_hash = blake3::hash(&summary.stdcode());
+        let my_summary_hash = summary.clean_hash();
         log::info!("about to verify summary hash: {:?}", my_summary_hash);
 
         // TODO: connect to a melnode in a "reverse-proxy" manner.

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -363,8 +363,8 @@ impl MasterSummary {
             exit_tree.insert(
                 exit.hostname.clone().into(),
                 (
-                    exit.signing_key.as_bytes().to_vec(),
-                    exit.sosistab_e2e_pk.as_bytes().to_vec(),
+                    hex::decode(exit.signing_key).unwrap(),
+                    hex::decode(exit.sosistab_e2e_pk.as_bytes()).unwrap(),
                 ),
             );
         }

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -244,14 +244,17 @@ pub struct MasterSummary {
 }
 
 impl MasterSummary {
+    /// Gets a hash of the [`MasterSummary`].
+    /// This clears out the `direct_route` vectors in each exit descriptor before hashing,
+    /// because they may randomly get switched out, making the hash value unstable.
     pub fn clean_hash(&self) -> blake3::Hash {
-        // get a copy with cleared out direct_route vectors in each exit descriptor
         let clean_exits: Vec<ExitDescriptor> = self
             .exits
             .iter()
             .map(|exit| {
                 let mut exit = exit.clone();
                 exit.direct_routes.clear();
+                exit.load = 0.0;
                 exit
             })
             .collect();

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -5,7 +5,7 @@ use chacha20poly1305::{
     aead::{Aead, NewAead},
     ChaCha20Poly1305, Nonce,
 };
-use nanorpc::nanorpc_derive;
+use nanorpc::{nanorpc_derive, JrpcError, JrpcRequest, JrpcResponse};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use smol_str::SmolStr;
@@ -68,6 +68,16 @@ pub enum BoxDecryptError {
     BadFormat,
 }
 
+#[derive(Error, Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum RpcError {
+    #[error("error retreiving bootstrap routes")]
+    BootstrapFailed,
+    #[error("error connecting to melnode")]
+    ConnectFailed,
+    #[error("error communicating with melnode")]
+    CommFailed,
+}
+
 #[nanorpc_derive]
 #[async_trait]
 pub trait BinderProtocol {
@@ -112,6 +122,9 @@ pub trait BinderProtocol {
 
     /// Obtains recent announcements, as a string containing an RSS feed.
     async fn get_announcements(&self) -> String;
+
+    /// Reverse proxies requests to melnode
+    async fn reverse_proxy_melnode(&self, req: JrpcRequest) -> Result<JrpcResponse, RpcError>;
 }
 /// Authentication request
 #[serde_as]

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -188,46 +188,6 @@ pub enum Credentials {
     },
 }
 
-impl FromStr for Credentials {
-    type Err = AuthError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts: Vec<&str> = s.split(':').collect();
-        match parts.get(0) {
-            Some(&"Password") => {
-                if parts.len() == 3 {
-                    Ok(Credentials::Password {
-                        username: parts[1].to_string().into(),
-                        password: parts[2].to_string().into(),
-                    })
-                } else {
-                    Err(AuthError::InvalidCredentials)
-                }
-            }
-            Some(&"Signature") => {
-                if parts.len() == 4 {
-                    let message = parts[3].to_string();
-                    let signature = parts[2].as_bytes().to_vec();
-                    let pubkey =
-                        Ed25519PK::from_str(parts[1]).map_err(|_| AuthError::InvalidCredentials);
-                    let pubkey = match pubkey {
-                        Ok(pubkey) => pubkey,
-                        Err(_) => return Err(AuthError::InvalidCredentials),
-                    };
-
-                    Ok(Credentials::Signature {
-                        pubkey,
-                        signature,
-                        message,
-                    })
-                } else {
-                    Err(AuthError::InvalidCredentials)
-                }
-            }
-            _ => Err(AuthError::InvalidCredentials),
-        }
-    }
-}
 /// Authentication response
 #[serde_as]
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -342,6 +342,7 @@ pub struct ExitDescriptor {
     pub country_code: SmolStr,
     pub city_code: SmolStr,
     pub direct_routes: Vec<BridgeDescriptor>,
+    #[serde(rename(serialize = "sosistab2_pk", deserialize = "sosistab2_pk"))]
     pub legacy_direct_sosistab_pk: x25519_dalek::PublicKey,
     pub allowed_levels: Vec<Level>,
     pub load: f64,

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -12,6 +12,7 @@ use smol_str::SmolStr;
 use std::net::SocketAddr;
 use stdcode::StdcodeSerializeExt;
 use thiserror::Error;
+use tmelcrypt::Ed25519PK;
 
 /// Encrypts a message, "box-style", to a destination diffie-hellman public key.
 pub fn box_encrypt(
@@ -155,7 +156,6 @@ pub struct AuthRequestV2 {
 type Username = SmolStr;
 type Password = SmolStr;
 type Signature = Vec<u8>;
-type Timestamp = u64;
 
 // geph4-client:
 
@@ -171,10 +171,10 @@ pub enum Credentials {
         password: Password,
     },
     Signature {
-        pubkey: x25519_dalek::PublicKey,
+        pubkey: Ed25519PK,
         // Derived from the given timestamp.
         signature: Signature,
-        timestamp: Timestamp,
+        message: String,
     },
 }
 

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -245,8 +245,7 @@ pub struct MasterSummary {
 
 impl MasterSummary {
     /// Gets a hash of the [`MasterSummary`].
-    /// This clears out the `direct_route` vectors in each exit descriptor before hashing,
-    /// because they may randomly get switched out, making the hash value unstable.
+    /// This clears out dynamically changing fields like `load` and `direct_route` in each exit descriptor before hashing.
     pub fn clean_hash(&self) -> blake3::Hash {
         let clean_exits: Vec<ExitDescriptor> = self
             .exits

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -5,7 +5,7 @@ use chacha20poly1305::{
     aead::{Aead, NewAead},
     ChaCha20Poly1305, Nonce,
 };
-use nanorpc::{nanorpc_derive, JrpcError, JrpcRequest, JrpcResponse};
+use nanorpc::{nanorpc_derive, JrpcRequest, JrpcResponse};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use smol_str::SmolStr;
@@ -260,7 +260,7 @@ impl MasterSummary {
     /// Gets a hash of the [`MasterSummary`].
     /// This clears out dynamically changing fields like `load` and `direct_route` in each exit descriptor before hashing.
     pub fn clean_hash(&self) -> blake3::Hash {
-        let clean_exits: Vec<ExitDescriptor> = self
+        let mut clean_exits: Vec<ExitDescriptor> = self
             .exits
             .iter()
             .map(|exit| {
@@ -270,6 +270,8 @@ impl MasterSummary {
                 exit
             })
             .collect();
+        // sort alphabetically by hostname
+        clean_exits.sort_by(|a, b| a.hostname.cmp(&b.hostname));
         let summary = MasterSummary {
             exits: clean_exits,
             bad_countries: self.bad_countries.clone(),

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -363,8 +363,8 @@ impl MasterSummary {
             exit_tree.insert(
                 exit.hostname.clone().into(),
                 (
-                    hex::decode(exit.signing_key).unwrap(),
-                    hex::decode(exit.sosistab_e2e_pk.as_bytes()).unwrap(),
+                    hex::encode(exit.signing_key).into(),
+                    hex::encode(exit.sosistab_e2e_pk.as_bytes()).into(),
                 ),
             );
         }

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -145,7 +145,7 @@ pub struct AuthRequest {
 #[serde_as]
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct AuthRequestV2 {
-    pub auth_kind: AuthKind,
+    pub credentials: Credentials,
     pub level: Level,
     pub epoch: u16,
     #[serde_as(as = "serde_with::base64::Base64")]
@@ -154,13 +154,28 @@ pub struct AuthRequestV2 {
 
 type Username = SmolStr;
 type Password = SmolStr;
+type Signature = Vec<u8>;
+type Timestamp = u64;
+
+// geph4-client:
+
+// - pass in private key (derive pubkey from private key)
+// - generate timestamp
+// - sign timestamp -> signature
 
 /// The different authentications methods available in AuthRequestV2
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]
-pub enum AuthKind {
-    Password(Username, Password),
-    Signature,
-    SignedTimestamp(),
+pub enum Credentials {
+    Password {
+        username: Username,
+        password: Password,
+    },
+    Signature {
+        pubkey: x25519_dalek::PublicKey,
+        // Derived from the given timestamp.
+        signature: Signature,
+        timestamp: Timestamp,
+    },
 }
 
 /// Authentication response

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -14,6 +14,8 @@ use stdcode::StdcodeSerializeExt;
 use thiserror::Error;
 use tmelcrypt::Ed25519PK;
 
+pub static AUTH_MSG_PREFIX: &str = "geph-auth-";
+
 /// Encrypts a message, "box-style", to a destination diffie-hellman public key.
 pub fn box_encrypt(
     plain: &[u8],

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -84,6 +84,9 @@ pub trait BinderProtocol {
     /// Authenticates a 24-hour-long session for a user.
     async fn authenticate(&self, auth_req: AuthRequest) -> Result<AuthResponse, AuthError>;
 
+    /// Authenticates a 24-hour-long session for a user.
+    async fn authenticate_v2(&self, auth_req: AuthRequestV2) -> Result<AuthResponseV2, AuthError>;
+
     /// Validates a blind signature token, applying rate-limiting as appropriate
     async fn validate(&self, token: BlindToken) -> bool;
 
@@ -149,10 +152,13 @@ pub struct AuthRequestV2 {
     pub blinded_digest: Bytes,
 }
 
+type Username = SmolStr;
+type Password = SmolStr;
+
 /// The different authentications methods available in AuthRequestV2
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum AuthKind {
-    Password(SmolStr, SmolStr),
+    Password(Username, Password),
     Signature,
 }
 
@@ -161,6 +167,15 @@ pub enum AuthKind {
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct AuthResponse {
     pub user_info: UserInfo,
+    #[serde_as(as = "serde_with::base64::Base64")]
+    pub blind_signature_bincode: Bytes,
+}
+
+/// Authentication response v2
+#[serde_as]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]
+pub struct AuthResponseV2 {
+    pub user_info: UserInfoV2,
     #[serde_as(as = "serde_with::base64::Base64")]
     pub blind_signature_bincode: Bytes,
 }
@@ -192,6 +207,13 @@ pub enum RegisterError {
 pub struct UserInfo {
     pub userid: i32,
     pub username: SmolStr,
+    pub subscription: Option<SubscriptionInfo>,
+}
+
+/// Information for a particular user v2
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct UserInfoV2 {
+    pub userid: i32,
     pub subscription: Option<SubscriptionInfo>,
 }
 

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -105,12 +105,13 @@ pub trait BinderProtocol {
         captcha_soln: SmolStr,
     ) -> Result<(), RegisterError>;
 
-    pub async fn register_user_v2(
+    /// Registers a new user.
+    async fn register_user_v2(
         &self,
         credentials: Credentials,
-        captcha_id: &str,
-        captcha_soln: &str,
-    ) -> anyhow::Result<Result<(), RegisterError>>;
+        captcha_id: SmolStr,
+        captcha_soln: SmolStr,
+    ) -> Result<(), RegisterError>;
 
     /// Deletes a user.
     /// NOTE: This is a legacy method, and will be deprecated later.
@@ -170,12 +171,6 @@ type Username = SmolStr;
 type Password = SmolStr;
 type Signature = Vec<u8>;
 
-// geph4-client:
-
-// - pass in private key (derive pubkey from private key)
-// - generate timestamp
-// - sign timestamp -> signature
-
 /// The different authentications methods available in AuthRequestV2
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum Credentials {
@@ -212,8 +207,8 @@ pub struct AuthResponseV2 {
 /// Authentication error
 #[derive(Error, Debug, Clone, Serialize, Deserialize)]
 pub enum AuthError {
-    #[error("invalid username or password")]
-    InvalidUsernameOrPassword,
+    #[error("invalid credentials")]
+    InvalidCredentials,
     #[error("too many requests")]
     TooManyRequests,
     #[error("level wrong")]
@@ -225,8 +220,8 @@ pub enum AuthError {
 /// Registration error
 #[derive(Error, Debug, Clone, Serialize, Deserialize)]
 pub enum RegisterError {
-    #[error("duplicate username")]
-    DuplicateUsername,
+    #[error("duplicate credentials")]
+    DuplicateCredentials,
     #[error("other error: {0}")]
     Other(SmolStr),
 }

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -160,6 +160,7 @@ type Password = SmolStr;
 pub enum AuthKind {
     Password(Username, Password),
     Signature,
+    SignedTimestamp(),
 }
 
 /// Authentication response
@@ -310,8 +311,10 @@ impl MasterSummary {
                 exit
             })
             .collect();
-        // sort alphabetically by hostname
+
+        // We sort alphabetically by hostname here to ensure that the generated hash is consistent, since the DB response may not guarantee ordering.
         clean_exits.sort_by(|a, b| a.hostname.cmp(&b.hostname));
+
         let summary = MasterSummary {
             exits: clean_exits,
             bad_countries: self.bad_countries.clone(),

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -327,7 +327,7 @@ pub struct BridgeDescriptor {
     pub is_direct: bool,
     pub protocol: SmolStr,
     pub endpoint: SocketAddr,
-    #[serde(rename(serialize = "sosistab_key", deserialize = "sosistab_key"))]
+    #[serde(rename = "sosistab_key")]
     pub cookie: Bytes,
     pub exit_hostname: SmolStr,
     pub alloc_group: SmolStr,
@@ -343,8 +343,8 @@ pub struct ExitDescriptor {
     pub country_code: SmolStr,
     pub city_code: SmolStr,
     pub direct_routes: Vec<BridgeDescriptor>,
-    #[serde(rename(serialize = "sosistab2_pk", deserialize = "sosistab2_pk"))]
-    pub legacy_direct_sosistab_pk: x25519_dalek::PublicKey,
+    #[serde(rename = "legacy_direct_sosistab_pk")]
+    pub sosistab_e2e_pk: x25519_dalek::PublicKey,
     pub allowed_levels: Vec<Level>,
     pub load: f64,
 }

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -83,6 +83,7 @@ pub enum RpcError {
 #[async_trait]
 pub trait BinderProtocol {
     /// Authenticates a 24-hour-long session for a user.
+    /// NOTE: This is a legacy method, and will be deprecated later.
     async fn authenticate(&self, auth_req: AuthRequest) -> Result<AuthResponse, AuthError>;
 
     /// Authenticates a 24-hour-long session for a user.
@@ -95,6 +96,7 @@ pub trait BinderProtocol {
     async fn get_captcha(&self) -> Result<Captcha, MiscFatalError>;
 
     /// Registers a new user.
+    /// NOTE: This is a legacy method, and will be deprecated later.
     async fn register_user(
         &self,
         username: SmolStr,
@@ -103,8 +105,19 @@ pub trait BinderProtocol {
         captcha_soln: SmolStr,
     ) -> Result<(), RegisterError>;
 
+    pub async fn register_user_v2(
+        &self,
+        credentials: Credentials,
+        captcha_id: &str,
+        captcha_soln: &str,
+    ) -> anyhow::Result<Result<(), RegisterError>>;
+
     /// Deletes a user.
+    /// NOTE: This is a legacy method, and will be deprecated later.
     async fn delete_user(&self, username: SmolStr, password: SmolStr) -> Result<(), AuthError>;
+
+    /// Deletes a user.
+    async fn delete_user_v2(&self, credentials: Credentials) -> Result<(), AuthError>;
 
     /// Adds a bridge route.
     async fn add_bridge_route(&self, descriptor: BridgeDescriptor) -> Result<(), MiscFatalError>;

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -363,8 +363,8 @@ impl MasterSummary {
             exit_tree.insert(
                 exit.hostname.clone().into(),
                 (
-                    hex::encode(exit.signing_key).into(),
-                    hex::encode(exit.sosistab_e2e_pk.as_bytes()).into(),
+                    exit.signing_key.as_bytes().to_vec(),
+                    exit.sosistab_e2e_pk.as_bytes().to_vec(),
                 ),
             );
         }

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -138,6 +138,24 @@ pub struct AuthRequest {
     pub blinded_digest: Bytes,
 }
 
+/// Authentication request generic over authentication type
+#[serde_as]
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]
+pub struct AuthRequestV2 {
+    pub auth_kind: AuthKind,
+    pub level: Level,
+    pub epoch: u16,
+    #[serde_as(as = "serde_with::base64::Base64")]
+    pub blinded_digest: Bytes,
+}
+
+/// The different authentications methods available in AuthRequestV2
+#[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]
+pub enum AuthKind {
+    Password(SmolStr, SmolStr),
+    Signature,
+}
+
 /// Authentication response
 #[serde_as]
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -9,10 +9,7 @@ use nanorpc::{nanorpc_derive, JrpcRequest, JrpcResponse};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use smol_str::SmolStr;
-use std::{
-    net::SocketAddr,
-    str::FromStr,
-};
+use std::{net::SocketAddr, str::FromStr};
 use stdcode::StdcodeSerializeExt;
 use thiserror::Error;
 use tmelcrypt::Ed25519PK;
@@ -176,18 +173,6 @@ type Username = SmolStr;
 type Password = SmolStr;
 type Signature = Vec<u8>;
 
-#[derive(Debug, Clone, Error)]
-pub struct ParseCredentialsError {
-    #[error("invalid credentials")]
-    Invalid(String),
-}
-
-impl fmt::Display for ParseCredentialsError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Failed to parse credentials")
-    }
-}
-
 /// The different authentications methods available in AuthRequestV2
 #[derive(Serialize, Deserialize, Clone, Debug, Hash, Eq, PartialEq)]
 pub enum Credentials {
@@ -223,7 +208,8 @@ impl FromStr for Credentials {
                 if parts.len() == 4 {
                     let message = parts[3].to_string();
                     let signature = parts[2].as_bytes().to_vec();
-                    let pubkey = Ed25519PK::from_str(parts[1]).map_err(|_| AuthError::InvalidCredentials);
+                    let pubkey =
+                        Ed25519PK::from_str(parts[1]).map_err(|_| AuthError::InvalidCredentials);
                     let pubkey = match pubkey {
                         Ok(pubkey) => pubkey,
                         Err(_) => return Err(AuthError::InvalidCredentials),

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -327,7 +327,8 @@ pub struct BridgeDescriptor {
     pub is_direct: bool,
     pub protocol: SmolStr,
     pub endpoint: SocketAddr,
-    pub sosistab_key: Bytes,
+    #[serde(rename(serialize = "sosistab_key", deserialize = "sosistab_key"))]
+    pub cookie: Bytes,
     pub exit_hostname: SmolStr,
     pub alloc_group: SmolStr,
     pub update_time: u64,


### PR DESCRIPTION
## Background
If a binder server gets compromised for whatever reason, the attacker can give out bad exit lists.

## Proposed Solution
To defend against a compromised binder server giving out bad exit lists, we can store a trusted `MasterSummary` hash on Mel using [`Gibbername`](https://docs.melproject.org/developer-guides/gibbername) and verify the binder server response against the hashes stored on-chain. 

When the exit list is changed on the binder server, the a `transfer` (rebinding) is also appended to the gibbername chain. 

This also uses the binder server as a reverse proxy in order to make the melnodes more censorship-resistant.

Credits to @sadministrator @nullchinchilla @thisbefruit