### PR TITLE
Update dependencies. Now geph4-protocol is compatiable with the newes…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ license="GPL-3.0-only"
 
 acidjson= "0.1.2"
 anyhow = "1.0.65"
-async-net = "1.7.0"
+async-net = "2.0.0"
 bincode = "1.3.3"
 bytes = { version = "1.2.1", features = ["serde"] }
-ed25519-dalek={ version = "1.0.1", features = ["serde"] }
-event-listener= "2.5.3"
-fastrand = "1.8.0"
+ed25519-dalek={ version = "2.1.1", features = ["serde"] }
+event-listener= "5.1.0"
+fastrand = "2.0.1"
 futures-util= "0.3.24"
 geph4-aioutils = "0.1.3"
 # geph4-binder-transport = "0.2"
@@ -26,32 +26,32 @@ hex = "0.4.3"
 log = "0.4.17"
 mizaru = "0.1.3"
 once_cell= "1.15.0"
-parking_lot = { version = "0.11.2", features = ["serde"] }
-rand= "0.7.3"
+parking_lot = { version = "0.12.1", features = ["serde"] }
+rand= "0.8.5"
 regex= "1.6.0"
 rsa-fdh = "0.5.0"
 serde={ version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
-sha2 = "0.9.9"
-smol= "1.2.5"
-smolscale= "0.3.41"
+sha2 = "0.10.8"
+smol= "2.0.0"
+smolscale= "0.4.4"
 smol-timeout = "0.6.0"
 #sosistab={path="../sosistab"}
-strsim = "0.10.0"
+strsim = "0.11.0"
 tap= "1.0.1"
 
-x25519-dalek={ version = "1.2.0", features = ["serde"], default-features=false }
+x25519-dalek={ version = "2.0.1", features = ["serde", "static_secrets"] }
 nanorpc = "0.1.7"
 async-trait = "0.1.57"
 thiserror = "1.0.37"
-smol_str = { version = "0.1.23", features = ["serde"] }
+smol_str = { version = "0.2.1", features = ["serde"] }
 stdcode = "0.1.10"
-base64 = "0.13.0"
-serde_with = {version="2.0.1", features=["base64", "hex"]}
+base64 = "0.21.7"
+serde_with = {version= "3.6.1", features=["base64", "hex"]}
 reqwest = "0.11.12"
 async-compat = "0.2.1"
 blake3 = "1.3.1"
-chacha20poly1305 = "0.7"
+chacha20poly1305 = "0.10.1"
 arrayref = "0.3.6"
 rsa = {version = "0.3", features=["serde"]}
 native-tls = {version="0.2", features=["vendored"]}

--- a/src/binder/client.rs
+++ b/src/binder/client.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, time::Duration};
+use std::time::Duration;
 
 use async_compat::CompatExt;
 use async_trait::async_trait;
@@ -27,7 +27,7 @@ impl RpcTransport for E2eeHttpTransport {
         &self,
         req: nanorpc::JrpcRequest,
     ) -> Result<nanorpc::JrpcResponse, Self::Error> {
-        let eph_sk = x25519_dalek::StaticSecret::new(rand::thread_rng());
+        let eph_sk = x25519_dalek::StaticSecret::random_from_rng(rand::thread_rng());
         let encrypted_req =
             box_encrypt(&serde_json::to_vec(&req)?, eph_sk.clone(), self.binder_lpk);
         let resp = self

--- a/src/binder/protocol.rs
+++ b/src/binder/protocol.rs
@@ -1,10 +1,7 @@
 use arrayref::array_ref;
 use async_trait::async_trait;
 use bytes::Bytes;
-use chacha20poly1305::{
-    aead::{Aead, NewAead},
-    ChaCha20Poly1305, Nonce,
-};
+use chacha20poly1305::{aead::Aead, ChaCha20Poly1305, KeyInit, Nonce};
 use nanorpc::{nanorpc_derive, JrpcRequest, JrpcResponse};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -350,7 +347,7 @@ pub struct BridgeDescriptor {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ExitDescriptor {
     pub hostname: SmolStr,
-    pub signing_key: ed25519_dalek::PublicKey,
+    pub signing_key: ed25519_dalek::VerifyingKey,
     pub country_code: SmolStr,
     pub city_code: SmolStr,
     pub direct_routes: Vec<BridgeDescriptor>,
@@ -394,9 +391,9 @@ mod tests {
     #[test]
     fn box_encryption() {
         let test_string = b"hello world";
-        let alice_sk = x25519_dalek::StaticSecret::new(rand::thread_rng());
+        let alice_sk = x25519_dalek::StaticSecret::random_from_rng(rand::thread_rng());
         let alice_pk = x25519_dalek::PublicKey::from(&alice_sk);
-        let bob_sk = x25519_dalek::StaticSecret::new(rand::thread_rng());
+        let bob_sk = x25519_dalek::StaticSecret::random_from_rng(rand::thread_rng());
         let bob_pk = x25519_dalek::PublicKey::from(&bob_sk);
         let encrypted = box_encrypt(test_string, alice_sk, bob_pk);
         let (decrypted, purported_alice_pk) = box_decrypt(&encrypted, bob_sk).unwrap();


### PR DESCRIPTION
…t sosistab2.